### PR TITLE
Update homepage for grad + new venture; mark SoCC'26 papers

### DIFF
--- a/src/content/home.md
+++ b/src/content/home.md
@@ -6,9 +6,9 @@ avatarImage:
 
 <div class="intro-section">
   <div class="intro-text">
-    <strong>CS Ph.D. Student @ Georgia Tech</strong></br>
-    Research Area: <strong>Systems for AI</strong>, <strong>LLM Inference</strong>
-    <p>I'm a final-year PhD student advised by <a href="https://faculty.cc.gatech.edu/~atumanov/">Prof. Alexey Tumanov</a>, building high-performance systems for foundation models. Currently building <a href="https://project-vajra.github.io">Vajra</a> - the world's fastest open-source AI inference engine, designed for real-time multimodal agentic workloads. <em>We're looking for talented systems builders to join us!</em></p>
+    <strong>Building something new in AI inference</strong></br>
+    <strong>CS Ph.D., Georgia Tech</strong> · Research Area: <strong>Systems for AI</strong>, <strong>LLM Inference</strong>
+    <p>I recently completed my PhD at Georgia Tech, advised by <a href="https://faculty.cc.gatech.edu/~atumanov/">Prof. Alexey Tumanov</a>, building high-performance systems for foundation models. I'm now building something new in AI inference — a serving engine for real-time multimodal workloads. <em>We're looking for talented systems builders to join us!</em></p>
   </div>
   <img src="/content/me.enc" alt="Amey Agrawal" class="intro-image" />
 </div>
@@ -16,10 +16,6 @@ avatarImage:
 ### Experience Timeline
 
 <div class="experience-timeline">
-<div class="timeline-item">
-  <span class="year">Present</span><span class="role">Project Lead</span> @ Project Vajra
-  <span class="detail">Mentor: Alexey Tumanov</span>
-</div>
 <div class="timeline-item">
   <span class="year">2025</span><span class="role">Research Intern</span> @ Microsoft Research <span class="detail">Mentors: Sadjad Fouladi & Ganesh Ananthanarayanan</span>
 </div>

--- a/src/content/projects/eval-checklist.md
+++ b/src/content/projects/eval-checklist.md
@@ -1,6 +1,7 @@
 ---
 title: "On Evaluating Performance of LLM Inference Serving Systems"
 published: 2025-01-30
+venue: "SoCC'26"
 authors: "Amey Agrawal, Nitin Kedia, Anmol Agarwal, Jayashree Mohan, Nipun Kwatra, Souvik Kundu, Ramachandran Ramjee, Alexey Tumanov"
 description: "Guidelines and checklist for evaluating LLM inference serving systems"
 tags: ["LLM Inference", "Evaluation", "Performance", "Benchmarking"]

--- a/src/content/projects/medha.md
+++ b/src/content/projects/medha.md
@@ -1,6 +1,7 @@
 ---
 title: "No Request Left Behind: Tackling Heterogeneity in Long-Context LLM Inference with Medha"
 published: 2025-01-25
+venue: "SoCC'26"
 authors: "Amey Agrawal, Haoran Qiu, Junda Chen, Íñigo Goiri, Chaojie Zhang, Rayyan Shahid, Ramachandran Ramjee, Alexey Tumanov, Esha Choukse"
 description: "Efficient serving of multi-million context length LLM inference requests without approximations"
 tags: ["LLM Inference", "Long Context", "Systems", "Memory Management"]

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -7,7 +7,7 @@ const config: SiteConfig = {
   title: 'Amey Agrawal',
   // The description of your site, used for SEO and RSS feed.
   description:
-    'Final-year PhD student at Georgia Tech working on systems for foundation models and LLM inference',
+    'Building high-performance systems for AI inference. CS PhD, Georgia Tech.',
   // The author of the site, used in the footer, SEO, and RSS feed.
   author: 'Amey Agrawal',
   // Keywords for SEO, used in the meta tags.


### PR DESCRIPTION
## Summary
- Reframe homepage intro: completed PhD at Georgia Tech, now building something new in AI inference (kept intentionally vague)
- Remove Vajra references (intro + timeline) and "final-year PhD student" framing
- Add `venue: SoCC'26` to **Medha** and **On Evaluating Performance of LLM Inference Serving Systems** (both accepted at SoCC'26)
- Update SEO description in `site.config.ts`

## Notes
- Timeline now starts at the 2025 MSR internship; no founder/startup entry per request
- Kept the "looking for systems builders to join us" line

🤖 Generated with [Claude Code](https://claude.com/claude-code)